### PR TITLE
flexible s3 path, before_add callback, more and more flexible params for post request to app

### DIFF
--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -66,4 +66,3 @@
 
 jQuery ->
   S3Uploader.init()
-


### PR DESCRIPTION
- Added 'key' parameter for rails upload helper
- The post request to the app now also sends the following parameter:
  - name = filename
  - path = path without filename and domain
  - file_size
  - file_type
- Wrapped the uploader into a Javascript object called S3Uploader to be able to dynamically set options and callbacks:
  - S3Uploader.path = path to file on s3
  - S3Uploader.before_add = callback to do checks on the selected files (e.g. for duplicates)
  - S3Uploader.extra_data = extra data that is sent to the rails app after the file has been uploaded to s3

I needed to add all this to get the uploader working with a file tree view I wrote. I hope this will be merged, as it makes the uploader more flexible in general.
