### PR TITLE
Added callback after file is uploaded and made POST optional

### DIFF
--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -43,9 +43,9 @@ $.fn.S3Uploader = (options) ->
         file = data.files[0]
         domain = $uploadForm.attr('action')
         path = settings.path + $uploadForm.find('input[name=key]').val().replace('/${filename}', '')
-        to = $uploadForm.data('post')
+
         content = {}
-        content[$uploadForm.data('as')] = domain + path + '/' + file.name
+        content.url = domain + path + '/' + file.name
         content.filename = file.name
         content.filepath = path
         if settings.additional_data
@@ -54,9 +54,14 @@ $.fn.S3Uploader = (options) ->
           content.filesize = file.size
         if 'type' of file
           content.filetype = file.type
-
-        $.post(to, content)
+        
+        to = $uploadForm.data('post')
+        if to
+          content[$uploadForm.data('as')] = content.url
+          $.post(to, content)
+        
         data.context.remove() if data.context # remove progress bar
+        $uploadForm.trigger("s3_upload_complete", [content])
 
         current_files.splice($.inArray(data, current_files), 1) # remove that element from the array
         if current_files.length == 0


### PR DESCRIPTION
I made a change to add more flexibility on how to handle when a file has been uploaded. In my case, I didn't want to make a POST to the server but just wanted to update an hidden field with the URL to the uploaded file.

So now, if the post option is not present on the form object, it won't make a post to the server. And I added an event that triggers a `s3_upload_complete` event on the `form` object with the `content` object.
