### PR TITLE
Fixed S3 policy error regarding expiry format

### DIFF
--- a/lib/s3_direct_upload/form_helper.rb
+++ b/lib/s3_direct_upload/form_helper.rb
@@ -16,7 +16,7 @@ module S3DirectUpload
           aws_secret_access_key: S3DirectUpload.config.secret_access_key,
           bucket: S3DirectUpload.config.bucket,
           acl: "public-read",
-          expiration: 10.hours.from_now,
+          expiration: 10.hours.from_now.utc.iso8601,
           max_file_size: 500.megabytes,
           as: "file",
           key: key


### PR DESCRIPTION
I'm not sure about this one but I was getting `Invalid Policy: Invalid 'expiration' value` when uploading to S3. I googled it and found someone else having the same problem : https://github.com/dwilkie/carrierwave_direct/pull/20

I converted the time to iso8601 like he did and it worked.
