### PR TITLE
Fix error when progress bar is not present

### DIFF
--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -30,7 +30,7 @@ $.fn.S3Uploader = (options) ->
         current_files.push data
         file = data.files[0]
         unless settings.before_add and not settings.before_add(file)
-          data.context = $(tmpl("template-upload", file))
+          data.context = $(tmpl("template-upload", file)) if $('#template-upload').length > 0
           $uploadForm.append(data.context)
           data.submit()
 


### PR DESCRIPTION
The uploader throws an error when the progress bar template is not present. This fixes it by verifying the presence of the template first.
