### PR TITLE
Make removing the progress bar after the download optional

### DIFF
--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -18,6 +18,7 @@ $.fn.S3Uploader = (options) ->
     path: ''
     additional_data: null
     before_add: null
+    remove_completed_progress_bar: true
 
   $.extend settings, options
 
@@ -60,7 +61,7 @@ $.fn.S3Uploader = (options) ->
           content[$uploadForm.data('as')] = content.url
           $.post(to, content)
         
-        data.context.remove() if data.context # remove progress bar
+        data.context.remove() if data.context && settings.remove_completed_progress_bar # remove progress bar
         $uploadForm.trigger("s3_upload_complete", [content])
 
         current_files.splice($.inArray(data, current_files), 1) # remove that element from the array


### PR DESCRIPTION
In one of my use cases, I need to keep the filename displayed on top of the progress bar once the file has been uploaded. So I added a config option named `remove_completed_progress_bar` to choose whether or not the progress bar should be removed once the file has finished uploading. It will remove it by default making it backward compatible.

Let me know if you think this might be a useful option. I will also update the documentation if you make the pull.
