### PR TITLE
Use the s3 xml response to set the file URL to avoid unicode confusion in Chrome

### DIFF
--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -74,16 +74,22 @@ $.fn.S3Uploader = (options) ->
         data
 
   build_content_object = ($uploadForm, file, result) ->
-    domain           = $uploadForm.attr('action')
-    path             = $('Key', result).text()
-    split_path       = path.split('/')
+    domain = $uploadForm.attr('action')
+    content = {}
+    if result # Use the S3 response to set the URL to avoid character encodings bugs
+      path             = $('Key', result).text()
+      split_path       = path.split('/')
+      content.url      = domain + path
+      content.filename = split_path[split_path.length - 1]
+      content.filepath = split_path.slice(0, split_path.length - 1).join('/')
+    else # IE8 and IE9 return a null result object so we use the file object instead
+      path             = settings.path + $uploadForm.find('input[name=key]').val().replace('/${filename}', '')
+      content.url      = domain + path + '/' + file.name
+      content.filename = file.name
+      content.filepath = path
 
-    content          = {}
-    content.url      = domain + path
-    content.filename = split_path[split_path.length - 1]
-    content.filepath = split_path.slice(0, split_path.length - 1).join('/')
-    content.filesize = file.size if 'size' of file
-    content.filetype = file.type if 'type' of file
+    content.filesize   = file.size if 'size' of file
+    content.filetype   = file.type if 'type' of file
     content = $.extend content, settings.additional_data if settings.additional_data
     content
 


### PR DESCRIPTION
This is a fix for issue #19 where in Chrome, the uploaded file name uses Unicode precomposed characters but the return URL from S3 uses combining characters. This breaks the URL.

After looking more into the issue with the help of @blueimp (https://github.com/blueimp/jQuery-File-Upload/issues/1339), it turns out we can either try to normalize the unicode string before uploading it to S3 or use the URL from the S3 response XML message.

I chose the second option since modifying the filename prior to the upload is not supported by all browsers.
