### PR TITLE
Change uplaoder.url bucket syntax

### DIFF
--- a/lib/s3_direct_upload/form_helper.rb
+++ b/lib/s3_direct_upload/form_helper.rb
@@ -53,7 +53,7 @@ module S3DirectUpload
       end
 
       def url
-        "https://s3.amazonaws.com/#{@options[:bucket]}"
+        "https://s3.amazonaws.com/#{@options[:bucket]}/"
       end
 
       def policy


### PR DESCRIPTION
Using https://s3.amazonaws.com/<BUCKET_NAME> instead of https://<BUCKET_NAME>.s3.amazonaws.com.

This fixes issues with SSL warnings and buckets using underscores (_)
