### PR TITLE
[ToDiscuss] Using $.widget ?

### DIFF
--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -1,108 +1,91 @@
-#= require jquery-fileupload/basic
-#= require jquery-fileupload/vendor/tmpl
+(($) ->
+  $.widget("waynehoover.s3upload", {
+    options: {
+      path: ''
+      additional_data: null
+      remove_completed_progress_bar: true
 
-$ = jQuery
+      before_add: null
+      start: null
+    }
+    _create: ->
+      @current_files = []
+      @form = $(this.element.prop("form"))
+      that = @
 
-$.fn.S3Uploader = (options) ->
+      @element.fileupload
+        add: (e, data) =>
+          @current_files.push data
+          file = data.files[0]
+          if @_trigger("before_add", null, {file: file})
+            data.context = $(tmpl("template-upload", file)) if $('#template-upload').length > 0
+            @form.append(data.context)
+            data.submit()
 
-  # support multiple elements
-  if @length > 1
-    @each ->
-      $(this).S3Uploader options
+        start: (e) =>
+          @_trigger("start")
 
-    return this
+        progress: (e, data) =>
+          data = $.extend({}, data, {percentage: parseInt(data.loaded / data.total * 100, 10)})
+          data.context.find('.bar').css('width', data.percentage + '%') if data.context
+          @_trigger("progress", e, data)
 
-  $uploadForm = this
+        done: (e, data) =>
+          content = @_buildContentObject data.files[0], data.result
 
-  settings =
-    path: ''
-    additional_data: null
-    before_add: null
-    remove_completed_progress_bar: true
+          to = @form.data('post')
+          if to
+            content[@form.data('as')] = content.url
+            $.post(to, content)
 
-  $.extend settings, options
+          data.context.remove() if data.context && @options.remove_completed_progress_bar # remove progress bar
 
-  current_files = []
+          @current_files.splice($.inArray(data, @current_files), 1) # remove that element from the array
+          @_trigger("done", e, content) unless @current_files.length
 
-  setUploadForm = ->
-    $uploadForm.fileupload
+        fail: (e, data) =>
+          content = @_buildContentObject data.files[0], data.result
+          content.error_thrown = data.errorThrown
+          @_trigger("fail", e, content)
 
-      add: (e, data) ->
-        current_files.push data
-        file = data.files[0]
-        unless settings.before_add and not settings.before_add(file)
-          data.context = $(tmpl("template-upload", file)) if $('#template-upload').length > 0
-          $uploadForm.append(data.context)
-          data.submit()
+        formData: (form) ->
+          data = form.serializeArray()
+          fileType = ""
+          if "type" of @files[0]
+            fileType = @files[0].type
+          data.push
+            name: "Content-Type"
+            value: fileType
 
-      start: (e) ->
-        $uploadForm.trigger("s3_uploads_start", [e])
+          data[1].value = that.options.path + data[1].value
 
-      progress: (e, data) ->
-        if data.context
-          progress = parseInt(data.loaded / data.total * 100, 10)
-          data.context.find('.bar').css('width', progress + '%')
+          data
 
-      done: (e, data) ->
-        content = build_content_object $uploadForm, data.files[0], data.result
+    _buildContentObject: (file, result) ->
+      domain = @form.attr('action')
+      content = {}
+      if result # Use the S3 response to set the URL to avoid character encodings bugs
+        path             = $('Key', result).text()
+        split_path       = path.split('/')
+        content.url      = domain + path
+        content.filename = split_path[split_path.length - 1]
+        content.filepath = split_path.slice(0, split_path.length - 1).join('/')
+      else # IE8 and IE9 return a null result object so we use the file object instead
+        path             = @options.path + @form.find('input[name=key]').val().replace('/${filename}', '')
+        content.url      = domain + path + '/' + file.name
+        content.filename = file.name
+        content.filepath = path
 
-        to = $uploadForm.data('post')
-        if to
-          content[$uploadForm.data('as')] = content.url
-          $.post(to, content)
+      content.filekey = "#{content.filepath}/#{content.filename}"
+      content.filesize   = file.size if 'size' of file
+      content.filetype   = file.type if 'type' of file
+      content = $.extend content, @options.additional_data if @options.additional_data
+      content
 
-        data.context.remove() if data.context && settings.remove_completed_progress_bar # remove progress bar
+    path: (new_path) ->
+      @options.path = new_path
 
-        current_files.splice($.inArray(data, current_files), 1) # remove that element from the array
-        $uploadForm.trigger("s3_uploads_complete", [content]) unless current_files.length
-
-      fail: (e, data) ->
-        content = build_content_object $uploadForm, data.files[0], data.result
-        content.error_thrown = data.errorThrown
-        $uploadForm.trigger("s3_upload_failed", [content])
-
-      formData: (form) ->
-        data = form.serializeArray()
-        fileType = ""
-        if "type" of @files[0]
-          fileType = @files[0].type
-        data.push
-          name: "Content-Type"
-          value: fileType
-
-        data[1].value = settings.path + data[1].value
-
-        data
-
-  build_content_object = ($uploadForm, file, result) ->
-    domain = $uploadForm.attr('action')
-    content = {}
-    if result # Use the S3 response to set the URL to avoid character encodings bugs
-      path             = $('Key', result).text()
-      split_path       = path.split('/')
-      content.url      = domain + path
-      content.filename = split_path[split_path.length - 1]
-      content.filepath = split_path.slice(0, split_path.length - 1).join('/')
-    else # IE8 and IE9 return a null result object so we use the file object instead
-      path             = settings.path + $uploadForm.find('input[name=key]').val().replace('/${filename}', '')
-      content.url      = domain + path + '/' + file.name
-      content.filename = file.name
-      content.filepath = path
-
-    content.filesize   = file.size if 'size' of file
-    content.filetype   = file.type if 'type' of file
-    content = $.extend content, settings.additional_data if settings.additional_data
-    content
-
-  #public methods
-  @initialize = ->
-    setUploadForm()
-    this
-
-  @path = (new_path) ->
-    settings.path = new_path
-
-  @additional_data = (new_data) ->
-    settings.additional_data = new_data
-
-  @initialize()
+    additional_data: (new_data) ->
+      @options.additional_data = new_data
+  })
+)(jQuery)


### PR DESCRIPTION
I started today using this awesome gem, it is much nicer than copying the Railscast code into each project. Additionally, the provided Javascript callbacks make it easy to adjust the plugin to some special needs. 

Nevertheless, I felt that the callbacks were quite difficult to use (e.g. `before_add` in options while others using `bind`, and they have different names than the events from fileupload widget), so I started refactoring the client code into a `$.widget`. Do you have any thoughts on this? Of course it isn't backwards-compatible, but I think the API is much easier to use.

List of changes:
- Plugin is initialized thorugh `$("#myS3Uploader").s3upload` instead of `$("#myS3Uploader").S3Uploader`
- Renamed events: `s3_upload_complete` => `s3uploaddone`, `s3_upload_failed` => `s3uploadfail`
- Introduce `progress` event that passes `loaded`, `total` and `percentage` properties
- Pass additional `filekey` property to `done` callback

<!---
@huboard:{"order":28.0,"milestone_order":28,"custom_state":""}
-->
