### PR TITLE
Add progress bar removal for failed uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Use the javascript in `s3_direct_upload` as a guide.
 * `additional_data:` You can send additional data to your rails app in the persistence POST request. This would be accessable in your params hash as  `params[:key][:value]`  
   Example: `{key: value}` 
 * `remove_completed_progress_bar:` By default, the progress bar will be removed once the file has been successfully uploaded. You can set this to `false` if you want to keep the progress bar.
+* `remove_failed_progress_bar:` By default, the progress bar will not be removed when uploads fail. You can set this to `true` if you want to remove the progress bar.
 * `before_add:` Callback function that executes before a file is added to the queue. It is passed file object and expects `true` or `false` to be returned. This could be useful if you would like to validate the filenames of files to be uploaded for example. If true is returned file will be uploaded as normal, false will cancel the upload.
 
 ### Example with all options.

--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -19,6 +19,7 @@ $.fn.S3Uploader = (options) ->
     additional_data: null
     before_add: null
     remove_completed_progress_bar: true
+    remove_failed_progress_bar: false
 
   $.extend settings, options
 
@@ -60,6 +61,8 @@ $.fn.S3Uploader = (options) ->
       fail: (e, data) ->
         content = build_content_object $uploadForm, data.files[0], data.result
         content.error_thrown = data.errorThrown
+
+        data.context.remove() if data.context && settings.remove_failed_progress_bar # remove progress bar
         $uploadForm.trigger("s3_upload_failed", [content])
 
       formData: (form) ->


### PR DESCRIPTION
Added the 'remove_failed_progress_bar' option, which makes the progress bar go away for failed uploads.

This helps when handling the failed event elsewhere via the `s3_upload_failed` event.
