### PR TITLE
Trivial bugfix for IE8

### DIFF
--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -41,7 +41,7 @@ $.fn.S3Uploader = (options) ->
         file.unique_id = Math.random().toString(36).substr(2,16)
 
         unless settings.before_add and not settings.before_add(file)
-          data.context = $(tmpl("template-upload", file).trim()) if $('#template-upload').length > 0
+          data.context = $($.trim(tmpl("template-upload", file))) if $('#template-upload').length > 0
           $(data.context).appendTo(settings.progress_bar_target || $uploadForm)
           if settings.click_submit_target
            forms_for_submit.push data


### PR DESCRIPTION
You have a call to .trim() which doesn't work in older browsers (e.g. IE8). Replacing it with $.trim() restores IE8 compatibility.
