### PR TITLE
readme: s3 can expire uploads automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ S3DirectUpload.config do |c|
 end
 ```
 
+Alternately, if you'd prefer for S3 to delete your old uploads automatically, you can do
+so by setting your bucket's 
+[Lifecycle Configuration](http://docs.aws.amazon.com/AmazonS3/latest/UG/LifecycleConfiguration.html).
+
 ## Contributing / TODO
 This is just a simple gem that only really provides some javascript and a form helper.
 This gem could go all sorts of ways based on what people want and how people contribute.


### PR DESCRIPTION
I don't know how new this feature is, but S3 has the ability to expire old uploads automatically for you. See http://docs.aws.amazon.com/AmazonS3/latest/UG/LifecycleConfiguration.html. I'm using it in my own application, and it's great. 

I've added this to the readme as an alternative to the rake task.
