### PR TITLE
Explicit callback handling with optional http method, and clearer callback data param names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Add the following js and css to your asset pipeline:
 ## Usage
 Create a new view that uses the form helper `s3_uploader_form`:
 ```ruby
-<%= s3_uploader_form post: model_url, as: "model[image_url]", id: "myS3Uploader" do %>
+<%= s3_uploader_form callback_url: model_url, callback_param: "model[image_url]", id: "myS3Uploader" do %>
   <%= file_field_tag :file, multiple: true %>
 <% end %>
 ```
@@ -74,8 +74,9 @@ Optionally, you can also place this template in the same view for the progress b
 ```
 
 ## Options for form helper
-* `post:` url in which is POST'd to after file is uploaded to S3. If you don't specify this option, no callback to the server will be made after the file has uploaded to S3.
-* `as:` parameter value for the POST in which the key will be the URL of the file on S3. If for example this is set to "model[image_url]" then the data posted would be `model[image_url] : http://bucketname.s3.amazonws.com/filename.ext`
+* `callback_url:` url in which is POST'd to after file is uploaded to S3. If you don't specify this option, no callback to the server will be made after the file has uploaded to S3.
+* `callback_method:` Defaults to POST. Use PUT and remove the multiple option from your file field to update a model.
+* `callback_param:` parameter value for the POST in which the key will be the URL of the file on S3. If for example this is set to "model[image_url]" then the data posted would be `model[image_url] : http://bucketname.s3.amazonws.com/filename.ext`
 * `key:` key on s3. defaults to `"uploads/#{SecureRandom.hex}/${filename}"`. needs to be at least `"${filename}"`.
 * `key_starts_with:` constraint on key on s3. Defaults to `uploads/`. if you change the `key` option, make sure this starts with what you put there. If you set this as a blank string the upload path to s3 can be anything, so be careful.
 * `acl:` acl for files uploaded to s3, defaults to "public-read"

--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -59,12 +59,12 @@ $.fn.S3Uploader = (options) ->
       done: (e, data) ->
         content = build_content_object $uploadForm, data.files[0], data.result
 
-        to = $uploadForm.data('post')
+        to = $uploadForm.data('callback-url')
         if to
-          content[$uploadForm.data('as')] = content.url
+          content[$uploadForm.data('callback-param')] = content.url
 
           $.ajax
-            type: 'POST'
+            type: $uploadForm.data('callback-method')
             url: to
             data: content
             beforeSend: ( xhr, settings )       -> $uploadForm.trigger( 'ajax:beforeSend', [xhr, settings] )

--- a/lib/s3_direct_upload/form_helper.rb
+++ b/lib/s3_direct_upload/form_helper.rb
@@ -21,7 +21,8 @@ module S3DirectUpload
           acl: "public-read",
           expiration: 10.hours.from_now.utc.iso8601,
           max_file_size: 500.megabytes,
-          as: "file",
+          callback_method: "POST",
+          callback_param: "file",
           key_starts_with: @key_starts_with,
           key: key
         )
@@ -35,8 +36,9 @@ module S3DirectUpload
           authenticity_token: false,
           multipart: true,
           data: {
-            post: @options[:post],
-            as: @options[:as]
+            callback_url: @options[:callback_url],
+            callback_method: @options[:callback_method],
+            callback_param: @options[:callback_param]
           }.reverse_merge(@options[:data] || {})
         }
       end


### PR DESCRIPTION
- Allowing override of default callback method by passing callback_method on form helper.
- Renamed "post" and "as" options to "callback_url" and "callback_param" for clarity
- Updated doc with instructions for updating an existing model

Related to https://github.com/waynehoover/s3_direct_upload/issues/44

Note: The renaming of the "post" and "as" options is a breaking change, but one that I feel is worthwhile for added options clarity.
