### PR TITLE
New unique path generation to prevent collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ Optionally, you can also place this template in the same view for the progress b
 ```
 
 ## Options for form helper
-* `callback_url:` url in which is POST'd to after file is uploaded to S3. If you don't specify this option, no callback to the server will be made after the file has uploaded to S3.
+* `callback_url:` url that is POST'd to after file is uploaded to S3. If you don't specify this option, no callback to the server will be made after the file has uploaded to S3.
 * `callback_method:` Defaults to POST. Use PUT and remove the multiple option from your file field to update a model.
 * `callback_param:` parameter value for the POST in which the key will be the URL of the file on S3. If for example this is set to "model[image_url]" then the data posted would be `model[image_url] : http://bucketname.s3.amazonws.com/filename.ext`
-* `key:` key on s3. defaults to `"uploads/#{SecureRandom.hex}/${filename}"`. needs to be at least `"${filename}"`.
-* `key_starts_with:` constraint on key on s3. Defaults to `uploads/`. if you change the `key` option, make sure this starts with what you put there. If you set this as a blank string the upload path to s3 can be anything, so be careful.
+* `key:` key on s3. defaults to `"uploads/{timestamp}-{unique_id}-#{SecureRandom.hex}/${filename}"`. `{timestamp}` and `{unique_id}` are special substitution params that will be populated by the javascript with values for the current upload. `${filename}` is a special s3 param that will be populated with the original upload file name. Needs to be at least `"${filename}"`. It is highly recommended to use both `{unique_id}`, which will prevent collisions when uploading files with the same name (such as from a mobile device, where every photo is named image.jpg), and a server-generated random value such as `#{SecureRandom.hex}`, which adds further collision protection with other uploaders.
+* `key_starts_with:` constraint on key on s3. Defaults to `uploads/`. if you change the `key` option, make sure this starts with what you put there. If you set this as a blank string the upload path to s3 can be anything - not recommended!
 * `acl:` acl for files uploaded to s3, defaults to "public-read"
 * `max_file_size:` maximum file size, defaults to 500.megabytes
 * `id:` html id for the form, its recommended that you give the form an id so you can reference with the jQuery plugin.

--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -96,7 +96,9 @@ $.fn.S3Uploader = (options) ->
           name: "Content-Type"
           value: fileType
 
-        data[1].value = settings.path + data[1].value #the key
+        # substitute upload timestamp and unique_id into key
+        key = data[1].value.replace('{timestamp}', new Date().getTime()).replace('{unique_id}', @files[0].unique_id)
+        data[1].value = settings.path + key
         data
 
   build_content_object = ($uploadForm, file, result) ->

--- a/lib/s3_direct_upload/form_helper.rb
+++ b/lib/s3_direct_upload/form_helper.rb
@@ -56,7 +56,7 @@ module S3DirectUpload
       end
 
       def key
-        @key ||= "#{@key_starts_with}#{DateTime.now.utc.strftime("%Y%m%dT%H%MZ")}_#{SecureRandom.hex}/${filename}"
+        @key ||= "#{@key_starts_with}{timestamp}-{unique_id}-#{SecureRandom.hex}/${filename}"
       end
 
       def url


### PR DESCRIPTION
Added javascript-generated timestamp and unique_id to upload paths for collision prevention when uploading files with the same name, such as from a mobile device.

https://github.com/waynehoover/s3_direct_upload/issues/72
