### PR TITLE
Got working with nested forms

### DIFF
--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -64,16 +64,15 @@ $.fn.S3Uploader = (options) ->
         if to
           content[$uploaderElement.data('callback-param')] = content.url
 
+          element = $(this)
           $.ajax
             type: $uploaderElement.data('callback-method')
             url: to
             data: content
-            beforeSend: ( xhr, settings )       -> $uploaderElement.trigger( 'ajax:beforeSend', [xhr, settings] )
-            complete:   ( xhr, status )         -> $uploaderElement.trigger( 'ajax:complete', [xhr, status] )
-            success:    ( data, status, xhr )   -> $uploaderElement.trigger( 'ajax:success', [data, status, xhr] )
-            error:      ( xhr, status, error )  -> $uploaderElement.trigger( 'ajax:error', [xhr, status, error] )
-
-          # $.post(to, content)
+            beforeSend: ( xhr, settings )       -> element.trigger( 'ajax:beforeSend', [xhr, settings] )
+            complete:   ( xhr, status )         -> element.trigger( 'ajax:complete', [xhr, status] )
+            success:    ( data, status, xhr )   -> element.trigger( 'ajax:success', [data, status, xhr] )
+            error:      ( xhr, status, error )  -> element.trigger( 'ajax:error', [xhr, status, error] )
 
         data.context.remove() if data.context && settings.remove_completed_progress_bar # remove progress bar
         $uploaderElement.trigger("s3_upload_complete", [content])
@@ -90,7 +89,6 @@ $.fn.S3Uploader = (options) ->
 
       formData: (form) ->
         data = $('.s3upload_hidden_fields').serializeArray()
-        #data = form.serializeArray()
         fileType = ""
         if "type" of @files[0]
           fileType = @files[0].type

--- a/lib/s3_direct_upload/form_helper.rb
+++ b/lib/s3_direct_upload/form_helper.rb
@@ -4,14 +4,14 @@ module S3DirectUpload
       uploader = S3Uploader.new(options)
       form_tag(uploader.url, uploader.form_options) do
         uploader.fields.map do |name, value|
-          hidden_field_tag(name, value)
+          hidden_field_tag(name, value, :class => "s3upload_hidden_fields")
         end.join.html_safe + capture(&block)
       end
     end
 
     def s3_uploader_hidden_fields(options = {}, &block)
       uploader = S3Uploader.new(options)
-      {:utf8 => ""}.merge(uploader.fields).map do |name, value|
+      (uploader.fields).map do |name, value|
         hidden_field_tag(name, value, :class => "s3upload_hidden_fields")
       end.join.html_safe
     end
@@ -98,7 +98,6 @@ module S3DirectUpload
         {
           expiration: @options[:expiration],
           conditions: [
-            ["starts-with", "$utf8", ""],
             ["starts-with", "$key", @options[:key_starts_with]],
             ["starts-with", "$x-requested-with", ""],
             ["content-length-range", 0, @options[:max_file_size]],


### PR DESCRIPTION
A solution for https://github.com/waynehoover/s3_direct_upload/issues/74

This allows you to use s3 direct upload without requiring a separate form.  To use with just an input tag within an existing form you will need to do a couple things.

Set the url for s3 uploader since it can no longer get it from the form

``` js
  $("#myS3Uploader").S3Uploader(
    {
    url: '<%=S3DirectUpload.config.url%>'
  });
```

This requires a url to be set in your uploader config

You can then include a file input tag using the following helpers

``` erb
<%= s3_uploader_hidden_fields%>
<%= s3_uploader_field callback_url: model_url, callback_param: "model[param_name]", id: "myS3Uploader"%>
```

However this will not work with the IE9 fix and I do not know anything about making it IE9 compatable
