### PR TITLE
Fix IE9 timestamp/unique_id not set bug

### DIFF
--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -99,6 +99,7 @@ $.fn.S3Uploader = (options) ->
         # substitute upload timestamp and unique_id into key
         key = data[1].value.replace('{timestamp}', new Date().getTime()).replace('{unique_id}', @files[0].unique_id)
         data[1].value = settings.path + key
+        $uploadForm.find("input[name='key']").val(data[1].value) # Force IE9 to set key
         data
 
   build_content_object = ($uploadForm, file, result) ->


### PR DESCRIPTION
`{timestamp}` and `{unique_id}` are not properly set in the value of the `#key` input element in IE9. This uses jQuery to nicely set it.
