### PR TITLE
Add back current_files.push (fix s3_uploads_complete callback)

### DIFF
--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -43,6 +43,7 @@ $.fn.S3Uploader = (options) ->
         file.unique_id = Math.random().toString(36).substr(2,16)
 
         unless settings.before_add and not settings.before_add(file)
+          current_files.push data
           data.context = $($.trim(tmpl("template-upload", file))) if $('#template-upload').length > 0
           $(data.context).appendTo(settings.progress_bar_target || $uploadForm)
           if settings.click_submit_target


### PR DESCRIPTION
For some reason `current_files.push data` was removed in this [commit](https://github.com/waynehoover/s3_direct_upload/commit/c0e96b80f29f4525767d68aca5ef1a9b133c57b3) which breaks s3_uploads_complete (it gets called on first file completion instead of last).
