### PR TITLE
Allow form helper to control content type policy

### DIFF
--- a/lib/s3_direct_upload/form_helper.rb
+++ b/lib/s3_direct_upload/form_helper.rb
@@ -76,7 +76,7 @@ module S3DirectUpload
             ["starts-with", "$key", @options[:key_starts_with]],
             ["starts-with", "$x-requested-with", ""],
             ["content-length-range", 0, @options[:max_file_size]],
-            ["starts-with","$content-type",""],
+            ["starts-with","$content-type", @options[:content_type_starts_with] ||""],
             {bucket: @options[:bucket]},
             {acl: @options[:acl]},
             {success_action_status: "201"}

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -15,5 +15,19 @@ describe S3DirectUpload::UploadHelper::S3Uploader do
         s3_uploader.policy_data[:conditions].should include ["starts-with", "$key", "uploads/"]
       end
     end
+
+    describe "starts-with $content-type" do
+      it "is configurable with the content_type_starts_with option" do
+        content_type_starts_with = "image/"
+        s3_uploader = S3DirectUpload::UploadHelper::S3Uploader.new({:content_type_starts_with => content_type_starts_with})
+        s3_uploader.policy_data[:conditions].should include ["starts-with", "$content-type", content_type_starts_with]
+      end
+
+      it "is defaults to an empty string" do
+        s3_uploader = S3DirectUpload::UploadHelper::S3Uploader.new({})
+        s3_uploader.policy_data[:conditions].should include ["starts-with", "$content-type", ""]
+      end
+    end
   end
+
 end


### PR DESCRIPTION
Based on the examples [here](http://docs.aws.amazon.com/AmazonS3/latest/dev/HTTPPOSTExamples.html), it seems like it is pretty straightforward to restrict the type of files using a stats-with policy. 

It used to default to an empty string. This patch allows a developer to supply another option to the form helper to customize that policy.
