### PR TITLE
It is not intended behavior to call a callback function during initializ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ jQuery ->
     path: 'path/to/my/files/on/s3'
     additional_data: {key: 'value'}
     remove_completed_progress_bar: false
-    before_add: myCallBackFunction() # must return true or false if set
+    before_add: myCallBackFunction # must return true or false if set
     progress_bar_target: $('.js-progress-bars')
     click_submit_target: $('.submit-target')
 ```


### PR DESCRIPTION
When following the example text calls the callback function during setup.
The callback fails to fire when files are being added.

Removing the "()" corrects this behavior.
