### PR TITLE
Fix typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Optionally, you can also place this template in the same view for the progress b
 
 ### Example with all options
 ```ruby
-<%= s3_uploader_form callback_url: model_url, callback_method: "POST", callback_param: "model[image_url]", key: "files/{timestamp}-{unique_id}-#{SecureRandom.hex}/${filename}", key_starts_with: "files/", acl: "public_read", max_file_size: 50.megabytes, id: "s3-uploader", class: "upload-form", data: {:key => :val} do %>
+<%= s3_uploader_form callback_url: model_url, callback_method: "POST", callback_param: "model[image_url]", key: "files/{timestamp}-{unique_id}-#{SecureRandom.hex}/${filename}", key_starts_with: "files/", acl: "public-read", max_file_size: 50.megabytes, id: "s3-uploader", class: "upload-form", data: {:key => :val} do %>
   <%= file_field_tag :file, multiple: true %>
 <% end %>
 ```


### PR DESCRIPTION
Hey all, minor patch here. In the "example with all options" it specifies the `acl` as `public_read` - this needs to be `public-read`.
