### PR TITLE
Allow setting of fileupload options through s3uploader

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Use the javascript in `s3_direct_upload` as a guide.
 * `before_add:` Callback function that executes before a file is added to the queue. It is passed file object and expects `true` or `false` to be returned. This could be useful if you would like to validate the filenames of files to be uploaded for example. If true is returned file will be uploaded as normal, false will cancel the upload.
 * `progress_bar_target:` The jQuery selector for the element where you want the progress bars to be appended to. Default is the form element.
 * `click_submit_target:` The jQuery selector for the element you wish to add a click handler to do the submitting instead of submiting on file open.
+* `fileupload_options:` Add any options that you wish to pass directly through to the underlying fileupload jQuery plugin. [View available options](https://github.com/blueimp/jQuery-File-Upload/wiki/Options).
 
 ### Example with all options
 ```coffeescript
@@ -147,6 +148,8 @@ jQuery ->
     before_add: myCallBackFunction() # must return true or false if set
     progress_bar_target: $('.js-progress-bars')
     click_submit_target: $('.submit-target')
+    fileupload_options:
+      limitConcurrentUploads: 5
 ```
 ### Example with single file upload bar without script template
 


### PR DESCRIPTION
This is a fairly simple change to address #125. I created a new settings option called fileupload_options which defaults to null. By passing any valid option from https://github.com/blueimp/jQuery-File-Upload/wiki/Options you can set the option directly in the fileupload plugin.

I simply moved all of the fileupload function overrides to an api object and them extended them with the new settings option. I intentionally made it so that someone could override even the s3uploader default API in case they wanted to extend it.

Let me know if you have any questions. 
