### PR TITLE
readme: split all options example into multiple lines for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,16 @@ Optionally, you can also place this template in the same view for the progress b
 
 ### Example with all options
 ```ruby
-<%= s3_uploader_form callback_url: model_url, callback_method: "POST", callback_param: "model[image_url]", key: "files/{timestamp}-{unique_id}-#{SecureRandom.hex}/${filename}", key_starts_with: "files/", acl: "public-read", max_file_size: 50.megabytes, id: "s3-uploader", class: "upload-form", data: {:key => :val} do %>
+<%= s3_uploader_form callback_url: model_url, 
+                     callback_method: "POST", 
+                     callback_param: "model[image_url]", 
+                     key: "files/{timestamp}-{unique_id}-#{SecureRandom.hex}/${filename}", 
+                     key_starts_with: "files/", 
+                     acl: "public-read", 
+                     max_file_size: 50.megabytes, 
+                     id: "s3-uploader", 
+                     class: "upload-form", 
+                     data: {:key => :val} do %>
   <%= file_field_tag :file, multiple: true %>
 <% end %>
 ```


### PR DESCRIPTION
I was getting a little frustrated scrolling back and forth there.... :flushed: 
