### PR TITLE
Replace filepath with key in callback request

### DIFF
--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -170,4 +170,7 @@ $.fn.S3Uploader = (options) ->
   @additional_data = (new_data) ->
     settings.additional_data = new_data
 
+  @get_additional_data = () ->
+    settings.additional_data
+
   @initialize()


### PR DESCRIPTION
I believe it is more useful to send the key instead of filepath to the callback_url. For example, I need the key to do additional processing on the server. Amazon also returns the key and probably for the same reason. I don't see any reason why not to return the data from Amazon (url and key) and return filepath instead.

Moreover, the current implementation has several issues in IE9:
- it was not returning the filepath, but only the path to the file. E.g. if the filepath would have been `/uploads/foo/bar.jpg` it was returning only `/uploads/foo`
- the filepath should start with a `/`. For filepaths such as `/uploads/foo/bar.jpg` it was returning only `uploads/foo`
- the filepath returned in IE9 was not encoded as it was in modern browsers.
