### PR TITLE
Ignore the add event from other fileupload forms on the same page

### DIFF
--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -37,7 +37,7 @@ $.fn.S3Uploader = (options) ->
     $uploadForm.fileupload
 
       add: (e, data) ->
-        return unless $uploadForm.is(e.originalEvent.target.form)
+        return unless $uploadForm.is(e.originalEvent.target.form) or e.originalEvent.target.form is null
 
         file = data.files[0]
         file.unique_id = Math.random().toString(36).substr(2,16)


### PR DESCRIPTION
When you currently have multiple file upload fields on the same page, the add event will be trigger for all of them.  This seems to be an issue with jquery-fileupload.  Unfortunately the target of the event will always point to the form of the s3_uploader (not the form of the actual file upload field), but the original event will point to the correct field.
