### PR TITLE
Add setting to support prepending files to progress_bar_target

### DIFF
--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -23,6 +23,7 @@ $.fn.S3Uploader = (options) ->
     progress_bar_target: null
     click_submit_target: null
     allow_multiple_files: true
+    prepend_files: null
 
   $.extend settings, options
 
@@ -44,7 +45,10 @@ $.fn.S3Uploader = (options) ->
           current_files.push data
           if $('#template-upload').length > 0
             data.context = $($.trim(tmpl("template-upload", file)))
-            $(data.context).appendTo(settings.progress_bar_target || $uploadForm)
+            if settings.prepend_files
+              $(data.context).prependTo(settings.progress_bar_target || $uploadForm)
+            else
+              $(data.context).appendTo(settings.progress_bar_target || $uploadForm)
           else if !settings.allow_multiple_files
             data.context = settings.progress_bar_target
           if settings.click_submit_target


### PR DESCRIPTION
This is a small change to add a setting called "prepend_files". When true, new files are prepended to the progress_bar_target instead of appended. Unless set, the current behavior to append files remains.

This prevents a common scenario that confuses users. When several files are uploading and new files are added, users often don't see the new files because they appear too far down the page. This setting ensures users get clear visual feedback.
