### PR TITLE
Include AWS Key param in callback post

### DIFF
--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -136,10 +136,12 @@ $.fn.S3Uploader = (options) ->
     if result # Use the S3 response to set the URL to avoid character encodings bugs
       content.url            = $(result).find("Location").text()
       content.filepath       = $('<a />').attr('href', content.url)[0].pathname
+      content.key            = $(result).find("Key").text()
     else # IE <= 9 retu      rn a null result object so we use the file object instead
       domain                 = $uploadForm.attr('action')
       content.filepath       = $uploadForm.find('input[name=key]').val().replace('/${filename}', '')
       content.url            = domain + content.filepath + '/' + encodeURIComponent(file.name)
+      content.key            = domain + content.filepath + '/' + file.name
 
     content.filename         = file.name
     content.filesize         = file.size if 'size' of file


### PR DESCRIPTION
Returning the key is important, when a filename contains Spaces or
other non-url safe characters the ‘Location’ parameter has encoded
them.  When this happens, it’s impossible to use the ‘url’ as the key
when referencing the file via the AWS SDK as a bucket object.

e.g. I upload a file called ‘I have spaces.txt’.  The ‘Location’ in
AWS’s response is ‘https://[bucket].s3.amazonaws.com/I+have+spaces.txt'
If we try to use this url to determine the key, URI.decode leaves the
+’s in there.  The +’s could have been part of the original filename
‘I+have+spaces.txt’.

There’s no good way to clean the filename before hand, so, this really
needs to return the key back to the callback url along with the
url/location.

It's important to provide the content unchanged so that it can be referenced via the API.
