### PR TITLE
removed dependency on sass

### DIFF
--- a/app/assets/stylesheets/s3_direct_upload_progress_bars.css
+++ b/app/assets/stylesheets/s3_direct_upload_progress_bars.css
@@ -3,15 +3,16 @@
   width: 400px;
   padding-top: 10px;
   margin-top: 10px;
+}
 
-  .progress {
+.upload .progress {
     margin-top: 8px;
     border: solid 1px #555;
     border-radius: 3px;
     -moz-border-radius: 3px;
-    .bar {
-      height: 10px;
-      background: #3EC144;
-    }
-  }
+}
+
+.upload .progress .bar {
+  height: 10px;
+  background: #3EC144;
 }

--- a/s3_direct_upload.gemspec
+++ b/s3_direct_upload.gemspec
@@ -17,6 +17,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'rails', '>= 3.1'
   gem.add_dependency 'coffee-rails', '>= 3.1'
-  gem.add_dependency 'sass-rails', '>= 3.1'
   gem.add_dependency 'jquery-fileupload-rails', '~> 0.4.1'
 end


### PR DESCRIPTION
I recently wanted to add this useful gem to a project built with less instead of sass.  Since the css for this gem is minimal I converted the sass to standard css which ultimately led to a break even on the lines of code.  To increase usability I recommend merging this change into master. 
