### PR TITLE
add region to clean task, fix default key_starts_with

### DIFF
--- a/lib/s3_direct_upload/form_helper.rb
+++ b/lib/s3_direct_upload/form_helper.rb
@@ -11,7 +11,7 @@ module S3DirectUpload
 
     class S3Uploader
       def initialize(options)
-        @key_starts_with = options[:key_starts_with] || "uploads/"
+        @key_starts_with = options[:key_starts_with] || "uploads/#{2.days.ago.strftime('%Y%m%d')}"
         @options = options.reverse_merge(
           aws_access_key_id: S3DirectUpload.config.access_key_id,
           aws_secret_access_key: S3DirectUpload.config.secret_access_key,

--- a/lib/tasks/s3_direct_upload.rake
+++ b/lib/tasks/s3_direct_upload.rake
@@ -4,7 +4,7 @@ namespace :s3_direct_upload do
     require 'thread'
     require 'fog'
 
-    s3     = Fog::Storage.new(provider: "AWS", aws_access_key_id: S3DirectUpload.config.access_key_id, aws_secret_access_key: S3DirectUpload.config.secret_access_key)
+    s3     = Fog::Storage.new(region: S3DirectUpload.config.region, provider: "AWS", aws_access_key_id: S3DirectUpload.config.access_key_id, aws_secret_access_key: S3DirectUpload.config.secret_access_key)
     bucket = S3DirectUpload.config.bucket
     prefix = S3DirectUpload.config.prefix_to_clean || "uploads/#{2.days.ago.strftime('%Y%m%d')}"
 


### PR DESCRIPTION
Its seems reasonable that the default of key_starts_with and prefix_to_clean would be the same, since now it will never work - if key_starts_with is timestamp, but the prefix to clean is a datestamp, no files will ever be found like this

Now, each file should get uploaded (defaultly) in a uploads/20141128 folder and when searching for files to clean it will search for objects that start with a datestamp and not a up-to-the-second time stamp.

Also, task was missing a region, so bucket in non default region caused errors. 
