### PR TITLE
Creating aws s3 url with Virtual Hosting

### DIFF
--- a/lib/s3_direct_upload/form_helper.rb
+++ b/lib/s3_direct_upload/form_helper.rb
@@ -61,7 +61,7 @@ module S3DirectUpload
       end
 
       def url
-        @options[:url] || "http#{@options[:ssl] ? 's' : ''}://#{@options[:region]}.amazonaws.com/#{@options[:bucket]}/"
+        @options[:url] || "http#{@options[:ssl] ? 's' : ''}://#{@options[:bucket]}.#{@options[:region]}.amazonaws.com/"
       end
 
       def policy


### PR DESCRIPTION
Using the convention described here: http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html