### PR TITLE
Do not send empty content-type to S3

### DIFF
--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -109,9 +109,10 @@ $.fn.S3Uploader = (options) ->
         fileType = ""
         if "type" of @files[0]
           fileType = @files[0].type
-        data.push
-          name: "content-type"
-          value: fileType
+        if fileType != ""
+          data.push
+            name: "content-type"
+            value: fileType
 
         key = $uploadForm.data("key")
           .replace('{timestamp}', new Date().getTime())

--- a/lib/s3_direct_upload/form_helper.rb
+++ b/lib/s3_direct_upload/form_helper.rb
@@ -69,18 +69,23 @@ module S3DirectUpload
       end
 
       def policy_data
+        conditions = [
+          ["starts-with", "$utf8", ""],
+          ["starts-with", "$key", @options[:key_starts_with]],
+          ["starts-with", "$x-requested-with", ""],
+          ["content-length-range", 0, @options[:max_file_size]],
+          {bucket: @options[:bucket]},
+          {acl: @options[:acl]},
+          {success_action_status: "201"}
+        ] + (@options[:conditions] || [])
+
+        if @options[:content_type_starts_with]
+          conditions.push(["starts-with","$content-type", @options[:content_type_starts_with]])
+        end
+
         {
           expiration: @options[:expiration],
-          conditions: [
-            ["starts-with", "$utf8", ""],
-            ["starts-with", "$key", @options[:key_starts_with]],
-            ["starts-with", "$x-requested-with", ""],
-            ["content-length-range", 0, @options[:max_file_size]],
-            ["starts-with","$content-type", @options[:content_type_starts_with] ||""],
-            {bucket: @options[:bucket]},
-            {acl: @options[:acl]},
-            {success_action_status: "201"}
-          ] + (@options[:conditions] || [])
+          conditions: conditions
         }
       end
 

--- a/spec/existance_spec.rb
+++ b/spec/existance_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 describe S3DirectUpload do
   it "version must be defined" do
-    S3DirectUpload::VERSION.should be_true
+    S3DirectUpload::VERSION.should be_truthy
   end
 
   it "config must be defined" do
-    S3DirectUpload.config.should be_true
+    S3DirectUpload.config.should be_truthy
   end
 
 end

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -23,9 +23,9 @@ describe S3DirectUpload::UploadHelper::S3Uploader do
         s3_uploader.policy_data[:conditions].should include ["starts-with", "$content-type", content_type_starts_with]
       end
 
-      it "is defaults to an empty string" do
+      it "is defaults to no constraint at all" do
         s3_uploader = S3DirectUpload::UploadHelper::S3Uploader.new({})
-        s3_uploader.policy_data[:conditions].should include ["starts-with", "$content-type", ""]
+        s3_uploader.policy_data[:conditions].should_not include ["starts-with", "$content-type", ""]
       end
     end
   end


### PR DESCRIPTION
Hi guys,

we encountered a problem with `*.idml` files. In the browsers the
`file.type` is the empty string `''`. Hence, S3 is sent

```bash
------WebKitFormBoundary....
Content-Disposition: form-data; name="content-type"

------WebKitFormBoundary....
Content-Disposition: form-data; name="file"; filename="example.idml"
Content-Type: application/octet-stream
```

which causes S3 to interpret this as a `.zip` file. When later
downloading the "example.idml" from S3 one is presented with a
"example.idml.zip" file. Not setting the content-type, if it is the
empty string, fixes this.

(Fixed two non-related specs as well for a happy Travis-CI :))