### PR TITLE
Use binary/octet-stream as the default content-type

### DIFF
--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -106,8 +106,8 @@ $.fn.S3Uploader = (options) ->
 
       formData: (form) ->
         data = form.serializeArray()
-        fileType = ""
-        if "type" of @files[0]
+        fileType = "binary/octet-stream"
+        if ("type" of @files[0]) && (@files[0].type != "")
           fileType = @files[0].type
         data.push
           name: "content-type"

--- a/spec/existance_spec.rb
+++ b/spec/existance_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 describe S3DirectUpload do
   it "version must be defined" do
-    S3DirectUpload::VERSION.should be_true
+    S3DirectUpload::VERSION.should be_truthy
   end
 
   it "config must be defined" do
-    S3DirectUpload.config.should be_true
+    S3DirectUpload.config.should be_truthy
   end
 
 end


### PR DESCRIPTION
Hi guys,

we encountered a problem with `*.idml` files. In the browser the
`file.type` is the empty string `''`. Hence, Amazon is sent

``` bash
------WebKitFormBoundary3aVHtVCO6rLQpIUz
Content-Disposition: form-data; name="content-type"

------WebKitFormBoundary3aVHtVCO6rLQpIUz
Content-Disposition: form-data; name="file"; filename="example.idml"
Content-Type: application/octet-stream
```

When later downloading the example.idml from S3 one is presented with a
"example.idml.zip" file. Using `binary/octet-stream` as the default
content-type fixes this.

`binary/octet-stream` is also the default content-type used by S3, if
no content-type is passed in the request.
See http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html

(Fixed two non-related specs as well for a happy Travis-CI :))
