### PR TITLE
Add "key" attribute to content object

### DIFF
--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -136,10 +136,12 @@ $.fn.S3Uploader = (options) ->
     if result # Use the S3 response to set the URL to avoid character encodings bugs
       content.url            = $(result).find("Location").text()
       content.filepath       = $('<a />').attr('href', content.url)[0].pathname
+      content.key            = $(result).find("Key").text()
     else # IE <= 9 retu      rn a null result object so we use the file object instead
       domain                 = $uploadForm.attr('action')
       content.filepath       = $uploadForm.find('input[name=key]').val().replace('/${filename}', '')
       content.url            = domain + content.filepath + '/' + encodeURIComponent(file.name)
+      content.key            = content.filepath + '/' + file.name
 
     content.filename         = file.name
     content.filesize         = file.size if 'size' of file


### PR DESCRIPTION
This way we can pass the object key in the POST request that follows an upload. This is useful when using acl="private", as we need to use pre-signed keys to access the objects anyways (and pre-signing requires an object key). Although it is possible to infer the key from the filepath attribute that the content object contains I felt it was really hacky and there was no reason not to pass back the actual key that AWS returns. 

