### PR TITLE
Adding the XHR object to the s3_upload_failed callback

### DIFF
--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -108,7 +108,7 @@ $.fn.S3Uploader = (options) ->
         content.error_thrown = data.errorThrown
 
         data.context.remove() if data.context && settings.remove_failed_progress_bar # remove progress bar
-        $uploadForm.trigger("s3_upload_failed", [content])
+        $uploadForm.trigger("s3_upload_failed", [content, data.jqXHR])
 
       formData: (form) ->
         data = $uploadForm.find("input").serializeArray()


### PR DESCRIPTION
As a solution for this issue: https://github.com/waynehoover/s3_direct_upload/issues/181
Sometimes more details about the failure is needed...