### PR TITLE
don't require a $ for the {filename} interpolation

### DIFF
--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -146,8 +146,8 @@ $.fn.S3Uploader = (options) ->
     else # IE <= 9 retu      rn a null result object so we use the file object instead
       domain                 = $uploadForm.find('input[type=file]').data('url')
       key                    = $uploadForm.find('input[name=key]').val()
-      content.filepath       = key.replace('/${filename}', '').replace('/{cleaned_filename}', '')
-      content.url            = domain + key.replace('/${filename}', encodeURIComponent(file.name))
+      content.filepath       = key.replace('/{filename}', '').replace('/{cleaned_filename}', '')
+      content.url            = domain + key.replace('/{filename}', encodeURIComponent(file.name))
       content.url            = content.url.replace('/{cleaned_filename}', cleaned_filename(file.name))
 
     content.filename         = file.name


### PR DESCRIPTION
This is more consistent with the other variables.

I started using ${cleaned_filename} and I noticed I was always getting a
$ at the front of my filenames, which led me to discover that actually
{cleaned_filename} was being used in the regex, not ${cleaned_filename}.

I think its probably easier to just be consistent for all the variables
and don't require a $.