### PR TITLE
Add an event that indicates that all upload attempts are complete

### DIFF
--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -102,6 +102,7 @@ $.fn.S3Uploader = (options) ->
 
         current_files.splice($.inArray(data, current_files), 1) # remove that element from the array
         $uploadForm.trigger("s3_uploads_complete", [content]) unless current_files.length
+        $uploadForm.trigger("s3_uploads_done", [content]) unless current_files.length
 
       fail: (e, data) ->
         content = build_content_object $uploadForm, data.files[0], data.result
@@ -109,6 +110,10 @@ $.fn.S3Uploader = (options) ->
 
         data.context.remove() if data.context && settings.remove_failed_progress_bar # remove progress bar
         $uploadForm.trigger("s3_upload_failed", [content])
+
+        current_files.splice($.inArray(data, current_files), 1) # remove that element from the array
+        $uploadForm.trigger("s3_uploads_done", [content]) unless current_files.length
+        console.log("done fail")
 
       formData: (form) ->
         data = $uploadForm.find("input").serializeArray()


### PR DESCRIPTION
Use case:

* User started uploading 2 files
* One of the files uploaded successfully
* The other upload fails (eg. file size limit exceeded)

With current implementation, `s3_upload_failed` event is fired but not `s3_uploads_complete`. So there is no way to know that all attempts to upload have succeeded.

This PR adds `s3_uploads_done` event that triggers no matter what happened - whether all uploads were succeeded or if they were failures (similar to jqXHR.always)