### PR TITLE
verison bump

### DIFF
--- a/lib/s3_direct_upload/version.rb
+++ b/lib/s3_direct_upload/version.rb
@@ -1,3 +1,3 @@
 module S3DirectUpload
-  VERSION = "0.1.7"
+  VERSION = "0.1.8"
 end


### PR DESCRIPTION
the view helper `s3_uploader_url` is not available in version 0.1.7, which breaks everything. 