### PR TITLE
Custom templates

### DIFF
--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -36,7 +36,7 @@ $.fn.S3Uploader = (options) ->
   setUploadForm = ->
     $uploadForm.fileupload
 
-      acceptFileTypes:  /(png|gif|jpg|jpeg)$/i
+      acceptFileTypes:  /(png)|(gif)|(jpg)|(jpeg)$/i
 
       add: (e, data) ->
         file = data.files[0]

--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -36,7 +36,7 @@ $.fn.S3Uploader = (options) ->
   setUploadForm = ->
     $uploadForm.fileupload
 
-      acceptFileTypes:  /(png)|(gif)|(jpg)|(jpeg)$/i
+      acceptFileTypes: /(\.|\/)(gif|jpe?g|png)$/i,
 
       add: (e, data) ->
         file = data.files[0]

--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -44,7 +44,7 @@ $.fn.S3Uploader = (options) ->
           current_files.push data
           if $('#template-upload').length > 0
             data.context = $($.trim(tmpl("template-upload", file)))
-            $(data.context).appendTo(settings.progress_bar_target || $uploadForm)
+            $(data.context).prependTo(settings.progress_bar_target || $uploadForm)
           else if !settings.allow_multiple_files
             data.context = settings.progress_bar_target
           if settings.click_submit_target

--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -1,6 +1,4 @@
-#= require jquery-fileupload/basic
-#= require jquery-fileupload/validate
-#= require jquery-fileupload/vendor/tmpl
+#= require jquery-fileupload
 
 $ = jQuery
 

--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -42,8 +42,8 @@ $.fn.S3Uploader = (options) ->
 
         unless settings.before_add and not settings.before_add(file)
           current_files.push data
-          if $('#template-upload').length > 0
-            data.context = $($.trim(tmpl("template-upload", file)))
+          if settings.template && $(settings.template).length > 0
+            data.context = $($.trim(tmpl(settings.template, file)))
             $(data.context).prependTo(settings.progress_bar_target || $uploadForm)
           else if !settings.allow_multiple_files
             data.context = settings.progress_bar_target

--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -36,6 +36,8 @@ $.fn.S3Uploader = (options) ->
   setUploadForm = ->
     $uploadForm.fileupload
 
+      acceptFileTypes:  /(png|gif|jpg|jpeg)$/i
+
       add: (e, data) ->
         file = data.files[0]
         file.unique_id = Math.random().toString(36).substr(2,16)

--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -36,13 +36,6 @@ $.fn.S3Uploader = (options) ->
   setUploadForm = ->
     $uploadForm.fileupload
 
-      before_add: (file) ->
-        regex = /(\.|\/)(gif|jpe?g|png)$/i;
-        if regex.test(file.name) == false
-          return false
-
-        return true
-
       add: (e, data) ->
         file = data.files[0]
         file.unique_id = Math.random().toString(36).substr(2,16)

--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -36,7 +36,12 @@ $.fn.S3Uploader = (options) ->
   setUploadForm = ->
     $uploadForm.fileupload
 
-      acceptFileTypes: /(\.|\/)(gif|jpe?g|png)$/i,
+      before_add: (file) ->
+        regex = /(\.|\/)(gif|jpe?g|png)$/i;
+        if regex.test(file.name) == false
+          return false
+
+        return true
 
       add: (e, data) ->
         file = data.files[0]

--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -1,4 +1,5 @@
-#= require jquery-fileupload
+#= require jquery-fileupload/basic
+#= require jquery-fileupload/vendor/tmpl
 
 $ = jQuery
 

--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -1,4 +1,5 @@
 #= require jquery-fileupload/basic
+#= require jquery-fileupload/validate
 #= require jquery-fileupload/vendor/tmpl
 
 $ = jQuery

--- a/app/assets/javascripts/s3_direct_upload.js.coffee
+++ b/app/assets/javascripts/s3_direct_upload.js.coffee
@@ -42,8 +42,8 @@ $.fn.S3Uploader = (options) ->
 
         unless settings.before_add and not settings.before_add(file)
           current_files.push data
-          if settings.template && $(settings.template).length > 0
-            data.context = $($.trim(tmpl(settings.template, file)))
+          if settings.template_id && $('#' + settings.template_id).length > 0
+            data.context = $($.trim(tmpl(settings.template_id, file)))
             $(data.context).prependTo(settings.progress_bar_target || $uploadForm)
           else if !settings.allow_multiple_files
             data.context = settings.progress_bar_target


### PR DESCRIPTION
This allows for a `template_id: 'id_string'` in the javascript to support multiple upload progress templates.